### PR TITLE
[Fix] 空 content 时不设置 content 字段导致下游收到缺失/非法 payload 并返回 400 的问题

### DIFF
--- a/examples/rag/run_ctp_rag.py
+++ b/examples/rag/run_ctp_rag.py
@@ -5,10 +5,10 @@ from vnag.object import Message, Request, Role, Segment
 from vnag.utility import load_json
 from vnag.gateways.openai_gateway import OpenaiGateway
 from vnag.segmenters.cpp_segmenter import CppSegmenter
-from vnag.vectors.chromadb_vector import ChromaVector
+from vnag.vectors.chromadb_vector import ChromadbVector
 
 
-def import_knowledge(vector: ChromaVector) -> None:
+def import_knowledge(vector: ChromadbVector) -> None:
     """
     遍历 CTP 头文件目录，使用 CppSegmenter 解析并将其插入向量数据库。
 
@@ -18,7 +18,7 @@ def import_knowledge(vector: ChromaVector) -> None:
     向量数据库中，以便后续的检索操作。
 
     Args:
-        vector (ChromaVector): 向量数据库的实例。
+        vector (ChromadbVector): 向量数据库的实例。
     """
     segmenter: CppSegmenter = CppSegmenter()
 
@@ -50,12 +50,12 @@ def import_knowledge(vector: ChromaVector) -> None:
             print(f"成功处理文件: {h_file.name}, 新增 {len(segments)} 个知识片段。")
 
 
-def query_vector(vector: ChromaVector, question: str, k: int = 5) -> list[Segment]:
+def query_vector(vector: ChromadbVector, question: str, k: int = 5) -> list[Segment]:
     """
     从向量数据库中查询与问题相关的知识片段。
 
     Args:
-        vector (ChromaVector): 向量数据库的实例。
+        vector (ChromadbVector): 向量数据库的实例。
         question (str): 用户提出的问题。
         k (int): 希望返回的相关知识片段数量。
 
@@ -78,7 +78,7 @@ def query_vector(vector: ChromaVector, question: str, k: int = 5) -> list[Segmen
 
 def generate_answer(
     gateway: OpenaiGateway,
-    vector: ChromaVector,
+    vector: ChromadbVector,
     question: str,
     model: str = "gpt-4o",
 ) -> str:
@@ -91,7 +91,7 @@ def generate_answer(
 
     Args:
         gateway (OpenaiGateway): AI 模型的调用接口。
-        vector (ChromaVector): 向量数据库的实例。
+        vector (ChromadbVector): 向量数据库的实例。
         question (str): 用户提出的问题。
         model (str): 希望使用的 AI 模型名称。
 
@@ -137,9 +137,9 @@ def main() -> None:
     CTP RAG Demo主程序入口。
     """
     # 1. 初始化向量数据库
-    # ChromaVector 默认会在当前工作目录下创建并使用 chroma 文件夹进行数据持久化
+    # ChromadbVector 默认会在当前工作目录下创建并使用 chroma 文件夹进行数据持久化
     embedder: SentenceEmbedder = SentenceEmbedder("BAAI/bge-large-zh-v1.5")
-    vector: ChromaVector = ChromaVector(name="ctp", embedder=embedder)
+    vector: ChromadbVector = ChromadbVector(name="ctp", embedder=embedder)
 
     print(f"向量数据库初始化完成，当前知识总数：{vector.count}")
 

--- a/examples/vector/run_chromadb_demo.py
+++ b/examples/vector/run_chromadb_demo.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from vnag.embedders.sentence_embedder import SentenceEmbedder
 from vnag.object import Segment
 from vnag.segmenters.markdown_segmenter import MarkdownSegmenter
-from vnag.vectors.chromadb_vector import ChromaVector
+from vnag.vectors.chromadb_vector import ChromadbVector
 
 
 def main() -> None:
@@ -33,12 +33,12 @@ def main() -> None:
 
     # 创建向量库（使用 BGE 本地模型，name="bge"）
     embedder: SentenceEmbedder = SentenceEmbedder("BAAI/bge-large-zh-v1.5")
-    vector: ChromaVector = ChromaVector(name="bge", embedder=embedder)
+    vector: ChromadbVector = ChromadbVector(name="bge", embedder=embedder)
 
     # 如需使用 DashScope API，替换为（注意修改 name）：
     # from vnag.embedders.dashscope_embedder import DashscopeEmbedder
     # embedder = DashscopeEmbedder(api_key="your_api_key", model_name="text-embedding-v3")
-    # vector = ChromaVector(name="dashscope", embedder=embedder)
+    # vector = ChromadbVector(name="dashscope", embedder=embedder)
 
     # 如需使用 OpenRouter API，替换为（注意修改 name）：
     # from vnag.embedders.openai_embedder import OpenaiEmbedder
@@ -47,7 +47,7 @@ def main() -> None:
     #     api_key="your_api_key",
     #     model_name="qwen/qwen3-embedding-8b"
     # )
-    # vector = ChromaVector(name="openai", embedder=embedder)
+    # vector = ChromadbVector(name="openai", embedder=embedder)
 
     # 写入向量库
     vector.add_segments(segments)

--- a/examples/vector/run_duckdb_demo.py
+++ b/examples/vector/run_duckdb_demo.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from vnag.embedders.sentence_embedder import SentenceEmbedder
 from vnag.object import Segment
 from vnag.segmenters.markdown_segmenter import MarkdownSegmenter
-from vnag.vectors.duckdb_vector import DuckVector
+from vnag.vectors.duckdb_vector import DuckdbVector
 
 
 def main() -> None:
@@ -33,12 +33,12 @@ def main() -> None:
 
     # 创建向量库（使用 BGE 本地模型，name="bge"）
     embedder: SentenceEmbedder = SentenceEmbedder("BAAI/bge-large-zh-v1.5")
-    vector: DuckVector = DuckVector(name="bge", embedder=embedder)
+    vector: DuckdbVector = DuckdbVector(name="bge", embedder=embedder)
 
     # 如需使用 DashScope API，替换为（注意修改 name）：
     # from vnag.embedders.dashscope_embedder import DashscopeEmbedder
     # embedder = DashscopeEmbedder(api_key="your_api_key", model_name="text-embedding-v3")
-    # vector = DuckVector(name="dashscope", embedder=embedder)
+    # vector = DuckdbVector(name="dashscope", embedder=embedder)
 
     # 如需使用 OpenRouter API，替换为（注意修改 name）：
     # from vnag.embedders.openai_embedder import OpenaiEmbedder
@@ -47,7 +47,7 @@ def main() -> None:
     #     api_key="your_api_key",
     #     model_name="qwen/qwen3-embedding-8b"
     # )
-    # vector = DuckVector(name="openai", embedder=embedder)
+    # vector = DuckdbVector(name="openai", embedder=embedder)
 
     # 写入向量库
     vector.add_segments(segments)

--- a/vnag/__main__.py
+++ b/vnag/__main__.py
@@ -3,6 +3,7 @@ from vnag.engine import AgentEngine
 from vnag.ui.window import MainWindow
 from vnag.ui.factory import create_gateway
 from vnag.ui.qt import create_qapp, QtWidgets
+from vnag.ui.tools import register_all
 
 
 def main() -> None:
@@ -13,6 +14,8 @@ def main() -> None:
 
     engine: AgentEngine = AgentEngine(gateway)
     engine.init()
+
+    register_all(engine)  # 注册 UI 专属工具
 
     window: MainWindow = MainWindow(engine)
     window.showMaximized()

--- a/vnag/gateways/litellm_gateway.py
+++ b/vnag/gateways/litellm_gateway.py
@@ -130,8 +130,7 @@ class LitellmGateway(OpenaiGateway):
             message_dict: dict[str, Any] = {"role": msg.role.value}
 
             # 处理内容
-            if msg.content:
-                message_dict["content"] = msg.content
+            message_dict["content"] = msg.content or ""
 
             # 处理 tool_calls
             if msg.tool_calls:

--- a/vnag/tools/search_tools.py
+++ b/vnag/tools/search_tools.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import quote
 
 import requests
 
@@ -159,7 +160,7 @@ def jina_search(
     Returns:
         搜索结果的 JSON 数据
     """
-    url: str = f"https://s.jina.ai/{requests.utils.quote(query)}"
+    url: str = f"https://s.jina.ai/{quote(query)}"
     headers: dict[str, str] = {"Accept": "application/json"}
 
     api_key: str = setting["jina_key"]

--- a/vnag/ui/knowledge.py
+++ b/vnag/ui/knowledge.py
@@ -1,0 +1,154 @@
+"""知识库管理模块"""
+from typing import Any
+from pathlib import Path
+from datetime import datetime
+import json
+
+from ..utility import get_folder_path, get_file_path
+from ..embedder import BaseEmbedder
+from ..vectors.duckdb_vector import DuckdbVector
+
+
+# 知识库存储目录
+KNOWLEDGE_DIR: str = "knowledge"
+
+
+def _get_metadata_path(name: str) -> Path:
+    """获取知识库元数据文件路径"""
+    folder: Path = get_folder_path(KNOWLEDGE_DIR)
+    return folder.joinpath(f"{name}.json")
+
+
+def _get_db_path(name: str) -> Path:
+    """获取知识库数据库文件路径"""
+    return get_file_path(f"{name}.duckdb")
+
+
+def list_knowledge_bases() -> list[dict[str, str]]:
+    """列出所有知识库
+
+    Returns:
+        知识库列表，每个元素包含 name 和 description
+    """
+    folder: Path = get_folder_path(KNOWLEDGE_DIR)
+    result: list[dict[str, str]] = []
+
+    for f in folder.glob("*.json"):
+        try:
+            with open(f, encoding="utf-8") as fp:
+                meta: dict[str, Any] = json.load(fp)
+                result.append({
+                    "name": meta["name"],
+                    "description": meta.get("description", "")
+                })
+        except Exception:
+            pass
+
+    return result
+
+
+def create_knowledge_base(
+    name: str,
+    embedder_type: str,
+    embedder_setting: dict[str, Any],
+    description: str = ""
+) -> None:
+    """创建知识库
+
+    Args:
+        name: 知识库名称
+        embedder_type: Embedder 类型（OpenAI / DashScope / Sentence）
+        embedder_setting: Embedder 构造参数
+        description: 知识库描述
+    """
+    path: Path = _get_metadata_path(name)
+    if path.exists():
+        raise ValueError(f"知识库 '{name}' 已存在")
+
+    metadata: dict[str, Any] = {
+        "name": name,
+        "description": description,
+        "embedder_type": embedder_type,
+        "embedder_setting": embedder_setting,
+        "created_at": datetime.now().isoformat()
+    }
+
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(metadata, f, indent=4, ensure_ascii=False)
+
+
+def load_knowledge_base(name: str) -> dict[str, Any] | None:
+    """加载知识库元数据
+
+    Args:
+        name: 知识库名称
+
+    Returns:
+        元数据字典，不存在则返回 None
+    """
+    path: Path = _get_metadata_path(name)
+    if not path.exists():
+        return None
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            return dict(json.load(f))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def delete_knowledge_base(name: str) -> None:
+    """删除知识库
+
+    Args:
+        name: 知识库名称
+    """
+    # 删除元数据文件
+    _get_metadata_path(name).unlink(missing_ok=True)
+
+    # 删除数据库文件
+    _get_db_path(name).unlink(missing_ok=True)
+
+    # 删除 WAL 文件
+    wal_path: Path = _get_db_path(name).with_suffix(".duckdb.wal")
+    wal_path.unlink(missing_ok=True)
+
+
+def _create_embedder(embedder_type: str, setting: dict[str, Any]) -> BaseEmbedder:
+    """根据类型和配置创建 Embedder 实例"""
+    if embedder_type == "OpenAI":
+        from ..embedders.openai_embedder import OpenaiEmbedder
+        return OpenaiEmbedder(**setting)
+    elif embedder_type == "DashScope":
+        from ..embedders.dashscope_embedder import DashscopeEmbedder
+        return DashscopeEmbedder(**setting)
+    elif embedder_type == "Sentence":
+        from ..embedders.sentence_embedder import SentenceEmbedder
+        return SentenceEmbedder(**setting)
+    else:
+        raise ValueError(f"不支持的 Embedder 类型: {embedder_type}")
+
+
+def get_knowledge_vector(name: str) -> DuckdbVector:
+    """获取知识库向量存储（自动创建专属 Embedder）
+
+    Args:
+        name: 知识库名称
+
+    Returns:
+        DuckdbVector 实例
+    """
+    from ..vectors.duckdb_vector import DuckdbVector
+
+    metadata: dict[str, Any] | None = load_knowledge_base(name)
+    if metadata is None:
+        raise ValueError(f"知识库 '{name}' 不存在")
+
+    embedder_type: str = metadata["embedder_type"]
+    setting: dict[str, Any] = metadata["embedder_setting"]
+
+    # 创建专属 Embedder
+    embedder: BaseEmbedder = _create_embedder(embedder_type, setting)
+
+    # 创建向量存储，使用知识库专用目录
+    return DuckdbVector(name=name, embedder=embedder)

--- a/vnag/ui/tools/__init__.py
+++ b/vnag/ui/tools/__init__.py
@@ -1,0 +1,41 @@
+"""UI 专属工具模块"""
+from pathlib import Path
+from importlib import import_module
+from glob import glob
+from typing import TYPE_CHECKING
+
+from vnag.local import LocalTool
+
+if TYPE_CHECKING:
+    from vnag.engine import AgentEngine
+
+
+def register_all(engine: "AgentEngine") -> None:
+    """注册所有 UI 专属工具到引擎
+
+    自动扫描当前目录下的所有 .py 文件，查找 LocalTool 实例并注册。
+
+    Args:
+        engine: AgentEngine 实例
+    """
+
+    folder: Path = Path(__file__).parent
+
+    for filepath in glob(str(folder / "*.py")):
+        filename: str = Path(filepath).stem
+
+        # 跳过 __init__.py 等特殊文件
+        if filename.startswith("_"):
+            continue
+
+        module_name: str = f"vnag.ui.tools.{filename}"
+
+        try:
+            module = import_module(module_name)
+
+            for name in dir(module):
+                value = getattr(module, name)
+                if isinstance(value, LocalTool):
+                    engine.register_tool(value)
+        except Exception:
+            pass

--- a/vnag/ui/tools/knowledge_tools.py
+++ b/vnag/ui/tools/knowledge_tools.py
@@ -1,0 +1,57 @@
+"""知识库工具模块"""
+from typing import Any
+
+from vnag.local import LocalTool
+from vnag.ui.knowledge import list_knowledge_bases as _list_knowledge_bases
+from vnag.ui.knowledge import get_knowledge_vector
+
+
+def list_knowledge_bases() -> list[dict[str, str]]:
+    """
+    获取本地已有的知识库列表。
+
+    Returns:
+        知识库列表，每个元素包含:
+        - name: 知识库名称
+        - description: 知识库描述
+    """
+    return _list_knowledge_bases()
+
+
+def query_knowledge_base(
+    name: str,
+    query: str,
+    k: int = 5
+) -> list[dict[str, Any]]:
+    """
+    在指定的知识库中查询与问题相关的知识片段。
+
+    Args:
+        name: 知识库名称
+        query: 查询问题
+        k: 返回的片段数量，默认5
+
+    Returns:
+        相关知识片段列表，每个包含:
+        - text: 片段文本
+        - metadata: 元数据（source, chunk_index, section_title等）
+        - score: 相似度分数（越小越相似）
+    """
+    vector = get_knowledge_vector(name)
+    segments = vector.retrieve(query, k=k)
+
+    results: list[dict[str, Any]] = []
+    for seg in segments:
+        results.append({
+            "text": seg.text,
+            "metadata": seg.metadata,
+            "score": seg.score
+        })
+
+    return results
+
+
+# 注册工具
+list_knowledge_bases_tool = LocalTool(list_knowledge_bases)
+
+query_knowledge_base_tool = LocalTool(query_knowledge_base)

--- a/vnag/ui/window.py
+++ b/vnag/ui/window.py
@@ -4,7 +4,14 @@ from ..engine import AgentEngine
 from ..utility import WORKING_DIR
 from ..agent import Profile, TaskAgent
 from .. import __version__
-from .widget import AgentWidget, ToolDialog, ModelDialog, ProfileDialog, GatewayDialog
+from .widget import (
+    AgentWidget,
+    ToolDialog,
+    ModelDialog,
+    ProfileDialog,
+    GatewayDialog,
+    KnowledgeDialog,
+)
 from .setting import get_setting
 from .qt import QtWidgets, QtGui, QtCore
 
@@ -123,9 +130,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
         function_menu: QtWidgets.QMenu = menu_bar.addMenu("功能")
         function_menu.addAction("AI服务配置", self.show_gateway_dialog)
-        function_menu.addAction("智能体配置", self.show_profile_dialog)
-        function_menu.addAction("工具浏览器", self.show_tool_dialog)
+        function_menu.addSeparator()
         function_menu.addAction("模型浏览器", self.show_model_dialog)
+        function_menu.addAction("工具浏览器", self.show_tool_dialog)
+        function_menu.addAction("智能体配置", self.show_profile_dialog)
+        function_menu.addSeparator()
+        function_menu.addAction("知识库管理", self.show_knowledge_dialog)
 
         help_menu: QtWidgets.QMenu = menu_bar.addMenu("帮助")
         help_menu.addAction("官网", self.open_website)
@@ -191,6 +201,11 @@ class MainWindow(QtWidgets.QMainWindow):
                 "AI服务配置已保存，需要重启应用程序才能生效。",
                 QtWidgets.QMessageBox.StandardButton.Ok
             )
+
+    def show_knowledge_dialog(self) -> None:
+        """显示知识库管理界面"""
+        dialog: KnowledgeDialog = KnowledgeDialog(self)
+        dialog.exec()
 
     def show_profile_dialog(self) -> None:
         """显示智能体管理界面"""


### PR DESCRIPTION
当最后一条 user 消息的 content 为空字符串 "" 时，gateway 用 if msg.content: 判断为假，没有设置 content 字段，发出的消息只有 {"role": "user"}。LiteLLM/下游在解析或转发时把缺失的 content 当成 null 或空对象，最终 Alibaba 收到的 messages.[0].content 为 object 而非 string，返回 400（expected string or array of objects, but got an object）。修复方式：对 content 始终赋值，使用 message_dict["content"] = msg.content or ""，保证空串或 None 时也发送 "content": ""，避免缺失字段导致下游报错
<img width="478" height="468" alt="4" src="https://github.com/user-attachments/assets/46da7a8b-f29d-402e-98db-f7e37a43716a" />
