### PR TITLE
Add MiniMax M2.5 models

### DIFF
--- a/vnag/gateways/minimax_gateway.py
+++ b/vnag/gateways/minimax_gateway.py
@@ -104,5 +104,7 @@ class MinimaxGateway(OpenaiGateway):
             "MiniMax-M2-Stable",
             "MiniMax-M2.1",
             "MiniMax-M2.1-Lighting",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-Lightning",
         ]
         return models


### PR DESCRIPTION
 wangweilong 新增'MiniMax-M2.5' 'MiniMax-M2.5-Lightning'  MinimaxGateway

## 描述
添加了 MiniMax-M2.5 和 MiniMax-M2.5-Lightning 两个模型到 MinimaxGateway。

## 更改内容
- 在 `list_models()` 方法中添加了 `MiniMax-M2.5` 和 `MiniMax-M2.5-Lightning` 模型

## 检查
- [x] ruff check 通过
- [x] mypy 类型检查通过